### PR TITLE
Separate flash message for logout

### DIFF
--- a/lib/sinatra_warden/sinatra.rb
+++ b/lib/sinatra_warden/sinatra.rb
@@ -81,6 +81,7 @@ module Sinatra
 
       app.set :auth_error_message,   "Could not log you in."
       app.set :auth_success_message, "You have logged in successfully."
+      app.set :logout_message, "You have logged out successfully."
       app.set :auth_template_renderer, :haml
       app.set :auth_login_template, :login
 
@@ -117,14 +118,14 @@ module Sinatra
       app.post '/login/?' do
         authenticate
         env['x-rack.flash'][:success] = options.auth_success_message if defined?(Rack::Flash)
-        redirect options.auth_use_referrer && session[:return_to] ? session.delete(:return_to) : 
+        redirect options.auth_use_referrer && session[:return_to] ? session.delete(:return_to) :
                  options.auth_success_path
       end
 
       app.get '/logout/?' do
         authorize!
         logout
-        env['x-rack.flash'][:success] = options.auth_success_message if defined?(Rack::Flash)
+        env['x-rack.flash'][:success] = options.logout_message if defined?(Rack::Flash)
         redirect options.auth_success_path
       end
     end

--- a/spec/sinatra_warden_spec.rb
+++ b/spec/sinatra_warden_spec.rb
@@ -176,9 +176,15 @@ describe "Sinatra::Warden" do
 
   context "Rack::Flash integration" do
 
-    it "should return a success message" do
+    it "should return a success message when logging in" do
       post '/login', 'email' => 'justin.smestad@gmail.com', 'password' => 'thedude'
       last_request.env['x-rack.flash'][:success].should == "You have logged in successfully."
+    end
+
+    it "should return a success message when logging out" do
+      post '/login', 'email' => 'justin.smestad@gmail.com', 'password' => 'thedude'
+      get  '/logout'
+      last_request.env['x-rack.flash'][:success].should == "You have logged out successfully."
     end
 
     it "should return an error message" do


### PR DESCRIPTION
Currently when I log out I get a 'You have logged in successfully' which is rather confusing. I defined a logout_message and use that when logging out.