### PR TITLE
Don't lose session[:return_to] when invalid credentials are submitted

### DIFF
--- a/lib/sinatra_warden/sinatra.rb
+++ b/lib/sinatra_warden/sinatra.rb
@@ -59,7 +59,7 @@ module Sinatra
       # @param [String] path to redirect to if user is unauthenticated
       def authorize!(failure_path=nil)
         unless authenticated?
-          session[:return_to] = request.path if options.auth_use_referrer
+          session[:return_to] = request.path if options.auth_use_referrer #&& !session[:return_to]
           redirect(failure_path ? failure_path : options.auth_failure_path)
         end
       end

--- a/lib/sinatra_warden/sinatra.rb
+++ b/lib/sinatra_warden/sinatra.rb
@@ -59,7 +59,7 @@ module Sinatra
       # @param [String] path to redirect to if user is unauthenticated
       def authorize!(failure_path=nil)
         unless authenticated?
-          session[:return_to] = request.path if options.auth_use_referrer #&& !session[:return_to]
+          session[:return_to] = request.path if options.auth_use_referrer && !session[:return_to]
           redirect(failure_path ? failure_path : options.auth_failure_path)
         end
       end

--- a/spec/sinatra_warden_spec.rb
+++ b/spec/sinatra_warden_spec.rb
@@ -74,6 +74,18 @@ describe "Sinatra::Warden" do
         follow_redirect!
         last_request.path.should == '/welcome'
       end
+
+      it "should keep an existing return_to intact" do
+        get '/dashboard'
+        follow_redirect!
+
+        post '/login', 'email' => 'justin.smestad@gmail.com', 'password' => 'wrong password'
+        last_request.session[:return_to].should == "/dashboard"
+
+        post '/login', 'email' => 'justin.smestad@gmail.com', 'password' => 'thedude'
+        follow_redirect!
+        last_request.path.should == "/dashboard"
+      end
     end
     
     context "TestingLoginAsRackApp" do


### PR DESCRIPTION
The scenario is the following:

1. Start unauthenticated
2. Visit a random page (/dashboard)
3. Browser is redirected to /login
4. Submit invalid credentials (typo, whatever)
5. /login rendered again
6. Submit correct credentials
7. Browser redirected to /unauthenticated

The test as written expresses my intent, but *DOES NOT* fail, thus this
pull request is to understand what I'm doing wrong. The change in
`sinatra.rb` was verified to work with my app.